### PR TITLE
Fix double input on Windows and improve warning display

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use crate::theme::Theme;
 use crate::tree::{FileTreeBuilder, FileTreeItem};
 use anyhow::Result;
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -27,7 +27,9 @@ use ratatui::{
     Frame, Terminal,
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout},
-    widgets::ListState,
+    style::{Color, Style},
+    text::Span,
+    widgets::{Block, Borders, ListState, Paragraph},
 };
 use std::io::{self, Read};
 use std::process::{Command, Stdio};
@@ -67,6 +69,7 @@ struct App {
     filtered_file_tree_items: Vec<FileTreeItem>, // Filtered items for search
     // UI state
     file_list_state: ListState, // For stateful file tree scrolling
+    warning_message: Option<String>, // Warning to display in the status bar
 }
 
 impl App {
@@ -75,14 +78,18 @@ impl App {
         file_diffs: Vec<FileDiff>,
         operation_mode: OperationMode,
     ) -> Result<Self> {
-        let diff_output = if file_diffs.is_empty() {
-            String::from("No diff content available")
-        } else {
-            file_diffs[0].content.clone()
-        };
-
         let file_tree_items = FileTreeBuilder::build_file_tree(&file_diffs);
         let theme = config.theme.clone();
+
+        let diff_output = if file_tree_items.is_empty() {
+            String::from("No diff content available")
+        } else if file_tree_items[0].is_directory {
+            format!("Directory: {}", file_tree_items[0].full_path)
+        } else if let Some(ref file_diff) = file_tree_items[0].file_diff {
+            file_diff.content.clone()
+        } else {
+            String::from("No diff content available")
+        };
 
         // Initialize persistence manager
         let persistence_manager = PersistenceManager::new()?;
@@ -128,6 +135,7 @@ impl App {
                 state.select(Some(0));
                 state
             },
+            warning_message: None,
         })
     }
 
@@ -204,8 +212,8 @@ impl App {
                         self.diff_output = processed_output;
                     }
                     Err(e) => {
-                        // Log error but continue with original output
-                        eprintln!("Warning: Failed to process with diff tool: {e}");
+                        self.warning_message =
+                            Some(format!("Failed to process with diff tool: {e}"));
                     }
                 }
             }
@@ -553,7 +561,8 @@ impl App {
                             .persistence_manager
                             .save_check_state(diff_key, is_now_checked)
                         {
-                            eprintln!("Warning: Failed to save check state: {e}");
+                            self.warning_message =
+                                Some(format!("Failed to save check state: {e}"));
                         }
                     }
                 }
@@ -699,7 +708,8 @@ impl App {
                                 self.diff_output = processed_output;
                             }
                             Err(e) => {
-                                eprintln!("Warning: Failed to refresh diff with width: {e}");
+                                self.warning_message =
+                                    Some(format!("Failed to refresh diff with width: {e}"));
                             }
                         }
                     }
@@ -740,7 +750,9 @@ impl App {
                                 self.diff_output = processed_output;
                             }
                             Err(e) => {
-                                eprintln!("Warning: Failed to refresh diff with area width: {e}");
+                                self.warning_message = Some(format!(
+                                    "Failed to refresh diff with area width: {e}"
+                                ));
                             }
                         }
                     }
@@ -1010,6 +1022,9 @@ fn run_app<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, mut app: Ap
         // Use poll to handle the case where stdin might not be available
         if event::poll(std::time::Duration::from_millis(100))? {
             if let Event::Key(key) = event::read()? {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
                 match key.code {
                     // Quit or exit search mode
                     KeyCode::Char('q') => {
@@ -1118,7 +1133,9 @@ fn run_app<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, mut app: Ap
 }
 
 fn ui(f: &mut Frame, app: &mut App) {
-    // Main horizontal split: file list (30%) and diff content area (70%)
+    let has_warning = app.warning_message.is_some();
+
+    // Main horizontal split: file list (20%) and diff content area (80%)
     let main_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(20), Constraint::Percentage(80)])
@@ -1137,14 +1154,40 @@ fn ui(f: &mut Frame, app: &mut App) {
         render_file_list(f, main_chunks[0], app);
     }
 
-    // Right side vertical split: status line and diff content
+    // Right side vertical split: status line, diff content, and optional warning
+    let right_constraints: Vec<Constraint> = if has_warning {
+        vec![
+            Constraint::Length(3),
+            Constraint::Min(0),
+            Constraint::Length(3),
+        ]
+    } else {
+        vec![Constraint::Length(3), Constraint::Min(0)]
+    };
+
     let right_chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(3), Constraint::Min(0)])
+        .constraints(right_constraints)
         .split(main_chunks[1]);
 
     render_status_line(f, right_chunks[0], app);
     render_diff_content(f, right_chunks[1], app);
+
+    // Render warning bar below diff content if present
+    if let Some(ref warning) = app.warning_message {
+        let warning_widget = Paragraph::new(Span::styled(
+            format!(" {warning}"),
+            Style::default().fg(app.theme.colors.status_bar_fg.0),
+        ))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Warning")
+                .style(Style::default().fg(Color::Yellow)),
+        )
+        .style(Style::default().fg(app.theme.colors.status_bar_fg.0));
+        f.render_widget(warning_widget, right_chunks[2]);
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,10 @@ use crate::config::{Config, DiffCommandType};
 use crate::git::GitExecutor;
 use crate::parser::{DiffFileKey, DiffParser, FileDiff};
 use crate::persistence::PersistenceManager;
-use crate::render::{render_diff_content, render_file_list, render_search_box, render_status_line};
+use crate::render::{
+    render_diff_content, render_file_list, render_search_box, render_status_line,
+    render_warning_bar,
+};
 use crate::theme::Theme;
 use crate::tree::{FileTreeBuilder, FileTreeItem};
 use anyhow::Result;
@@ -27,9 +30,7 @@ use ratatui::{
     Frame, Terminal,
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout},
-    style::{Color, Style},
-    text::Span,
-    widgets::{Block, Borders, ListState, Paragraph},
+    widgets::ListState,
 };
 use std::io::{self, Read};
 use std::process::{Command, Stdio};
@@ -69,7 +70,7 @@ struct App {
     filtered_file_tree_items: Vec<FileTreeItem>, // Filtered items for search
     // UI state
     file_list_state: ListState, // For stateful file tree scrolling
-    warning_message: Option<String>, // Warning to display in the status bar
+    warning_message: Option<String>, // Warning to display in the warning bar below the diff pane
 }
 
 impl App {
@@ -210,6 +211,7 @@ impl App {
                 match self.execute_external_diff_tool_with_width(&self.diff_output, width) {
                     Ok(processed_output) => {
                         self.diff_output = processed_output;
+                        self.warning_message = None;
                     }
                     Err(e) => {
                         self.warning_message =
@@ -706,6 +708,7 @@ impl App {
                         match self.execute_external_diff_tool_with_width(&base_diff, Some(width)) {
                             Ok(processed_output) => {
                                 self.diff_output = processed_output;
+                                self.warning_message = None;
                             }
                             Err(e) => {
                                 self.warning_message =
@@ -748,6 +751,7 @@ impl App {
                         ) {
                             Ok(processed_output) => {
                                 self.diff_output = processed_output;
+                                self.warning_message = None;
                             }
                             Err(e) => {
                                 self.warning_message = Some(format!(
@@ -1022,7 +1026,7 @@ fn run_app<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, mut app: Ap
         // Use poll to handle the case where stdin might not be available
         if event::poll(std::time::Duration::from_millis(100))? {
             if let Event::Key(key) = event::read()? {
-                if key.kind != KeyEventKind::Press {
+                if key.kind == KeyEventKind::Release {
                     continue;
                 }
                 match key.code {
@@ -1174,19 +1178,8 @@ fn ui(f: &mut Frame, app: &mut App) {
     render_diff_content(f, right_chunks[1], app);
 
     // Render warning bar below diff content if present
-    if let Some(ref warning) = app.warning_message {
-        let warning_widget = Paragraph::new(Span::styled(
-            format!(" {warning}"),
-            Style::default().fg(app.theme.colors.status_bar_fg.0),
-        ))
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" Warning")
-                .style(Style::default().fg(Color::Yellow)),
-        )
-        .style(Style::default().fg(app.theme.colors.status_bar_fg.0));
-        f.render_widget(warning_widget, right_chunks[2]);
+    if app.warning_message.is_some() {
+        render_warning_bar(f, right_chunks[2], app);
     }
 }
 
@@ -1281,6 +1274,22 @@ mod tests {
         let content = buffer_to_string(buffer);
         assert!(content.contains("Diff Content"));
         assert!(content.contains("No diff content available"));
+    }
+
+    #[test]
+    fn test_render_warning_bar() {
+        let backend = TestBackend::new(100, 50);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let config = Config::default();
+        let mut app = App::new(config, vec![], OperationMode::GitWorkingDirectory).unwrap();
+        app.warning_message = Some("Failed to process with diff tool: program not found".into());
+
+        terminal.draw(|f| ui(f, &mut app)).unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let content = buffer_to_string(buffer);
+        assert!(content.contains("Warning"));
+        assert!(content.contains("Failed to process with diff tool"));
     }
 
     fn buffer_to_string(buffer: &Buffer) -> String {

--- a/src/render.rs
+++ b/src/render.rs
@@ -404,3 +404,20 @@ pub fn render_search_box(f: &mut Frame, area: Rect, app: &App) {
 
     f.render_widget(search_box, area);
 }
+
+pub fn render_warning_bar(f: &mut Frame, area: Rect, app: &App) {
+    if let Some(ref warning) = app.warning_message {
+        let warning_widget = Paragraph::new(Span::styled(
+            format!(" {warning}"),
+            Style::default().fg(app.theme.colors.status_bar_fg.0),
+        ))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Warning")
+                .style(Style::default().fg(app.theme.colors.warning_border.0)),
+        )
+        .style(Style::default().fg(app.theme.colors.status_bar_fg.0));
+        f.render_widget(warning_widget, area);
+    }
+}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -132,6 +132,14 @@ pub struct ColorScheme {
 
     // Background colors
     pub background: ThemeColor,
+
+    // Warning colors
+    #[serde(default = "default_warning_border")]
+    pub warning_border: ThemeColor,
+}
+
+fn default_warning_border() -> ThemeColor {
+    ThemeColor(Color::Yellow)
 }
 
 impl Default for ColorScheme {
@@ -170,6 +178,9 @@ impl ColorScheme {
 
             // Background colors
             background: ThemeColor(Color::Black),
+
+            // Warning colors
+            warning_border: ThemeColor(Color::Yellow),
         }
     }
 }


### PR DESCRIPTION
_This is an awesome project, and just what I was looking for as I spend more time in a terminal!_

   Fixes #25

   ### Changes

   #### Double input fix (Windows)
   On Windows, crossterm emits both `Press` and `Release` key events. The event loop now filters for `KeyEventKind::Press` only, preventing every keystroke from being processed twice.

   #### In-app warning bar
   `eprintln!` calls during TUI rendering (e.g., when a configured diff tool like `delta` isn't installed) were corrupting the terminal display. Warnings are now shown in a persistent,  themed warning bar below the diff content pane instead of writing to stderr.

   #### Initial directory display
   When the first item in the file tree is a directory, the diff pane now correctly shows "Directory: ..." on initial load instead of displaying the raw diff content of the first file.

   ### Testing
   All 21 existing tests pass. Changes were manually verified on Windows.

### Disclaimer

Paired with GitHub Copilot on this change. First time using Ratatui. 